### PR TITLE
Performance Improvement

### DIFF
--- a/stat_binscatter.R
+++ b/stat_binscatter.R
@@ -8,10 +8,12 @@ StatBinscatter <- ggplot2::ggproto(
     y_means  <- stats::ave(data$y, x_bin, FUN = mean)
     y_se     <- stats::ave(data$y, x_bin, FUN = sd)
     y_obs    <- stats::ave(data$y, x_bin, FUN = length)
-    return(data.frame(x    = x_means, 
-                      y    = y_means, 
-                      ymax = y_means + 1.96*y_se/sqrt(y_obs),
-                      ymin = y_means - 1.96*y_se/sqrt(y_obs)))
+    result   <- data.frame(x    = x_means, 
+                           y    = y_means, 
+                           ymax = y_means + 1.96*y_se/sqrt(y_obs),
+                           ymin = y_means - 1.96*y_se/sqrt(y_obs))
+    result   <- unique(result)
+    return(result)
   },
   required_aes = c("x", "y")
 )


### PR DESCRIPTION
Removed duplicates from the internal data.frame, leading to nrow(result) == bins. Before, nrow(result) equaled the length of the input data. This adjustment significantly reduces the plotting time. In a benchmark experiment with >1E6 rows, it went down by a factor of 7 (113 sec to 16 sec)